### PR TITLE
Add @kenchris to author list

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 
 ## Authors:
 
-* Olivier Yiptong
-* Victor Costan
+* Olivier Yiptong (Google)
+* Victor Costan (Google)
+* Kenneth Rohde Christiansen (Intel)
 
 
 ## Participate


### PR DESCRIPTION
This adds Kenneth Rohde Christiansen to the author list in the explainer.